### PR TITLE
Feature/fix build and launch vscode task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,16 +2,13 @@
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
+    "version": "0.2.1",
     "configurations": [
         {
             "name": "ROS: Launch",
             "type": "ros",
             "request": "launch",
-            "preLaunchTask": {
-                "task": "build",
-                "type": "catkin_make"
-            },
+            "preLaunchTask": "build",
             "target": "/home/sonia/ros_sonia_ws/src/provider_power/launch/provider_power.launch",
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,8 +5,9 @@
     "tasks": [
         {
             "type": "catkin_make",
-            "problemMatcher": [
-                "$catkin-gcc"
+            "args": [
+                "--directory",
+                "/home/sonia/ros_sonia_ws"
             ],
             "group": {
                 "kind": "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,7 +1,7 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-    "version": "2.0.0",
+    "version": "2.0.1",
     "tasks": [
         {
             "type": "catkin_make",


### PR DESCRIPTION
## Description
Changed the catkin_make arguments to make it run ehan calling the build task in vscode.
Corrected also the launch task.

## How has this been tested ?
- Tested on my machine by calling the command

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings